### PR TITLE
From to range by month

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
         </div>
     </div>
     <div class="container mt-3">
-        <div class="row mb-4">
+        <!-- <div class="row mb-4">
             <div class="col-2">
                 <select id="year" class="form-select">
                   <option selected>2021</option>
@@ -70,6 +70,57 @@
             </div>
             <div class="col-2">
                 <select id="month" class="form-select">
+                  <option>01</option>
+                  <option selected>02</option>
+                  <option>03</option>
+                  <option>04</option>
+                  <option>05</option>
+                  <option>06</option>
+                  <option>07</option>
+                  <option>08</option>
+                  <option>09</option>
+                  <option>10</option>
+                  <option>11</option>
+                  <option>12</option>
+                </select>
+            </div>
+            <div class="col-2">
+                <button type="button" class="btn btn-primary" id="submit">Показати</button>
+            </div>
+        </div> -->
+        <div class="row mb-4">
+            <div class="col-2">
+                <select id="year-from" class="form-select">
+                  <option selected>2021</option>
+                  <option>2022</option>
+                </select>
+            </div>
+            <div class="col-2">
+                <select id="month-from" class="form-select">
+                  <option>01</option>
+                  <option selected>02</option>
+                  <option>03</option>
+                  <option>04</option>
+                  <option>05</option>
+                  <option>06</option>
+                  <option>07</option>
+                  <option>08</option>
+                  <option>09</option>
+                  <option>10</option>
+                  <option>11</option>
+                  <option>12</option>
+                </select>
+            </div>
+            <div class="col-1">
+            </div>
+            <div class="col-2">
+                <select id="year-to" class="form-select">
+                  <option selected>2021</option>
+                  <option>2022</option>
+                </select>
+            </div>
+            <div class="col-2">
+                <select id="month-to" class="form-select">
                   <option>01</option>
                   <option selected>02</option>
                   <option>03</option>
@@ -160,6 +211,12 @@
         let selectedYear = document.getElementById("year")
         let selectedMonth = document.getElementById("month")
 
+        let selectedYearFrom = document.getElementById("year-from")
+        let selectedMonthFrom = document.getElementById("month-from")
+
+        let selectedYearTo = document.getElementById("year-to")
+        let selectedMonthTo = document.getElementById("month-to")
+
         let submitButton = document.getElementById("submit")
 
         let chart = document.getElementById("sankey_voting")
@@ -186,6 +243,70 @@
             setTimeout("drawLoadProgress()", 300);
         }
 
+        // TODO: make it less tricky
+        async function getDataForChartRange() {
+
+            barContainer.hidden = false
+            chart.innerHTML = ''
+
+            loadedDocs.current = 0
+
+            datarows = []
+
+            let dataFilesToGet = []
+
+            if(selectedYearFrom.value == selectedYearTo.value) {
+
+                let values = dataFiles[selectedYearFrom.value]
+
+                for (const month in values) {
+                    if ((parseInt(month) >= parseInt(selectedMonthFrom.value)) && (parseInt(month) <= parseInt(selectedMonthTo.value))) {
+                        values[month].forEach(document => dataFilesToGet.push(document))               
+                    }
+                }
+            } else {
+                for (const year in dataFiles) {
+                    // if (parseInt(year) == parseInt(selectedYearFrom.value)) {
+                    //     dataFiles[year].forEach(month => {
+                    //         if(parseInt(month) >= selectedMonthFrom) {
+                    //             dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                    //         }
+                    //     })
+                    // }
+
+                    if (parseInt(year) == parseInt(selectedYearFrom.value)) {
+                        for (const month in dataFiles[year]) {
+                            if(parseInt(month) >= selectedMonthFrom.value) {
+                                dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                            }
+                        }
+                    }
+                    else if (parseInt(year) == parseInt(selectedYearTo.value)) {
+                        for (const month in dataFiles[year]) {
+                            if(parseInt(month) <= selectedMonthTo.value) {
+                                dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                            }
+                        }
+                    }
+                    else {
+                        for (const month in dataFiles[year]) {
+                            dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                        }                    
+                    }
+                }
+            }
+
+            loadedDocs.total = dataFilesToGet.length
+
+            drawLoadProgress()
+
+            for (const document of dataFilesToGet) {
+                await getDataFile(document).then(res => datarows.push(res)).then(() => loadedDocs.current++) 
+            }
+
+            barContainer.hidden = true
+        }
+
         async function getDataForChart() {
 
             barContainer.hidden = false
@@ -208,7 +329,7 @@
 
         window.addEventListener('load', async () => { 
             dataFiles = await getDateMap()
-            await getDataForChart()
+            await getDataForChartRange()
 
             votesByCategory = getVotingResultsByCategory(datarows)
             drawChart(votesByCategory)
@@ -224,7 +345,7 @@
         })
 
         submitButton.addEventListener('click', async () => {
-            await getDataForChart()
+            await getDataForChartRange()
 
             votesByCategory = getVotingResultsByCategory(datarows)
 

--- a/index.html
+++ b/index.html
@@ -240,7 +240,7 @@
                 bar.innerText = `${loadedDocs.current}/${loadedDocs.total}`
             }
 
-            setTimeout("drawLoadProgress()", 300);
+            setTimeout("drawLoadProgress()", 10);
         }
 
         // TODO: make it less tricky
@@ -261,7 +261,7 @@
 
                 for (const month in values) {
                     if ((parseInt(month) >= parseInt(selectedMonthFrom.value)) && (parseInt(month) <= parseInt(selectedMonthTo.value))) {
-                        values[month].forEach(document => dataFilesToGet.push(document))               
+                        dataFilesToGet.push(values[month])
                     }
                 }
             } else {
@@ -277,20 +277,20 @@
                     if (parseInt(year) == parseInt(selectedYearFrom.value)) {
                         for (const month in dataFiles[year]) {
                             if(parseInt(month) >= selectedMonthFrom.value) {
-                                dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                                dataFilesToGet.push(dataFiles[year][month])
                             }
                         }
                     }
                     else if (parseInt(year) == parseInt(selectedYearTo.value)) {
                         for (const month in dataFiles[year]) {
                             if(parseInt(month) <= selectedMonthTo.value) {
-                                dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                                dataFilesToGet.push(dataFiles[year][month])
                             }
                         }
                     }
                     else {
                         for (const month in dataFiles[year]) {
-                            dataFiles[year][month].forEach(document => dataFilesToGet.push(document))
+                            dataFilesToGet.push(dataFiles[year][month])
                         }                    
                     }
                 }
@@ -303,7 +303,7 @@
             let promises = []
 
             for (const document of dataFilesToGet) {
-                promises.push(getDataFile(document))
+                promises.push(getMonthDataFile(document))
             }
 
             const handleProgress = (result) => {
@@ -311,12 +311,8 @@
                 return result;
             }
 
-            // await Promise.all(promises).then(results => { 
-            //     results.forEach(res => datarows.push(res))  
-            // })
-
             await Promise.all(promises.map(p => p.then(handleProgress))).then(results => { 
-                results.forEach(res => datarows.push(res))    
+                results.forEach(res => res.forEach(entry => datarows.push(entry)))    
             })
 
 
@@ -344,7 +340,7 @@
         }
 
         window.addEventListener('load', async () => { 
-            dataFiles = await getDateMap()
+            dataFiles = await getDateMapByMonth()
             await getDataForChartRange()
 
             votesByCategory = getVotingResultsByCategory(datarows)

--- a/index.html
+++ b/index.html
@@ -300,9 +300,25 @@
 
             drawLoadProgress()
 
+            let promises = []
+
             for (const document of dataFilesToGet) {
-                await getDataFile(document).then(res => datarows.push(res)).then(() => loadedDocs.current++) 
+                promises.push(getDataFile(document))
             }
+
+            const handleProgress = (result) => {
+                loadedDocs.current++
+                return result;
+            }
+
+            // await Promise.all(promises).then(results => { 
+            //     results.forEach(res => datarows.push(res))  
+            // })
+
+            await Promise.all(promises.map(p => p.then(handleProgress))).then(results => { 
+                results.forEach(res => datarows.push(res))    
+            })
+
 
             barContainer.hidden = true
         }

--- a/js/chart-drawers.js
+++ b/js/chart-drawers.js
@@ -7,9 +7,6 @@ function drawChart(categoryVoting) {
     google.charts.load('current', {'packages':['sankey']})
     google.charts.setOnLoadCallback(drawSankeyChart)
 
-    yearDefined = year
-    monthDefined = month
-
     function drawSankeyChart() {
 
         let data = new google.visualization.DataTable();

--- a/js/data-getter.js
+++ b/js/data-getter.js
@@ -9,6 +9,14 @@ async function getDateMap() {
     return await fetchData(BASE_URL + 'date-files-map/date-map.json')
 }
 
+async function getDateMapByMonth() {
+    return await fetchData(BASE_URL + 'date-files-map/date-map-month.json')
+}
+
 async function getDataFile(fileName) {
     return await fetchData(`${BASE_URL}data-final-lite/${fileName}`)
+}
+
+async function getMonthDataFile(fileName) {
+    return await fetchData(`${BASE_URL}data-final-lite-month/${fileName}`)
 }


### PR DESCRIPTION
Use data gathered by month instead of fetching individual decision jsons, works faster, and a workaround for `net::ERR_INSUFFICIENT_RESOURCES` in Chrome when fetching 1000+ items 